### PR TITLE
added maxlength in redis xadd

### DIFF
--- a/options.go
+++ b/options.go
@@ -21,6 +21,7 @@ type options struct {
 	cluster          bool
 	group            string
 	consumer         string
+	maxLength		 int64	
 }
 
 // WithAddr setup the addr of redis
@@ -92,6 +93,12 @@ func WithLogger(l queue.Logger) Option {
 		w.logger = l
 	}
 }
+
+func WithMaxLength(m int64) Option {
+	return func(w *options) {
+		w.maxLength = m
+	}
+} 
 
 func newOptions(opts ...Option) options {
 	defaultOpts := options{

--- a/redis.go
+++ b/redis.go
@@ -208,8 +208,7 @@ func (w *Worker) queue(data interface{}) error {
 	// Publish a message.
 	err := w.rdb.XAdd(ctx, &redis.XAddArgs{
 		Stream:       w.opts.streamName,
-		MaxLen:       0,
-		MaxLenApprox: 0,
+		MaxLen:       w.opts.maxLength,
 		Values:       data,
 	}).Err()
 


### PR DESCRIPTION
#### ISSUE
- redis memory was increasing continuously and there were no measures to clean it up once it was not required

#### FIX
- added max length parameter which takes number of maximum entries in the redis stream. It will act like a FIFO queue so whenever there is message and queue is full it will evict the first entry. 

#### Memory stats
- It was taking around 200mb for 50k entries.